### PR TITLE
Fix inspection of functions with no arguments

### DIFF
--- a/schemainspect/pg/functions.sql
+++ b/schemainspect/pg/functions.sql
@@ -89,7 +89,7 @@ with r1 as (
             pg_get_function_result(oid) as result_string,
             pg_get_function_identity_arguments(oid) as identity_arguments
         FROM r
-            JOIN information_schema.parameters p ON
+            LEFT JOIN information_schema.parameters p ON
                 r.specific_name=p.specific_name
         order by
             name, parameter_mode, ordinal_position, parameter_name


### PR DESCRIPTION
Given the following schema:

```SQL
create function foof() returns int as $$ select 1 $$ language sql;
create view foov as select foof();
```

schemainspect fails with the following error:

```
Traceback (most recent call last):
  File "foo.py", line 5, in <module>
    i = get_inspector(s)
  File "/home/marko/ff/mainenv/lib/python3.4/site-packages/schemainspect/get.py", line 19, in get_inspector
    return ic(c)
  File "/home/marko/ff/mainenv/lib/python3.4/site-packages/schemainspect/pg/__init__.py", line 331, in __init__
    super(PostgreSQL, self).__init__(c, include_internal)
  File "/home/marko/ff/mainenv/lib/python3.4/site-packages/schemainspect/inspector.py", line 25, in __init__
    self.load_all()
  File "/home/marko/ff/mainenv/lib/python3.4/site-packages/schemainspect/pg/__init__.py", line 340, in load_all
    self.load_deps()
  File "/home/marko/ff/mainenv/lib/python3.4/site-packages/schemainspect/pg/__init__.py", line 357, in load_deps
    self.selectables[x_dependent_on].dependents.append(x)
KeyError: '"public"."foof"()'
```

The problem seems to be in functions.sql, which excludes functions with no arguments.  The view has a dependency on it, causing the crash; but obviously the problem is present even without the view.

After this patch self.functions looks like the following:

```
OrderedDict([('"public"."foof"()', InspectedFunction(columns=OrderedDict([('foof', ColumnInfo(dbtype=None, dbtypestr=None, default=None, enum=None, is_enum=False, name='foof', not_null=False, pytype=<class 'int'>))]), constraints=OrderedDict(), definition=' select 1 ', dependent_on=[], dependent_on_all=[], dependents=[], dependents_all=[], identity_arguments='', indexes=OrderedDict(), inputs=[], language='SQL', name='foof', relationtype='f', result_string='integer', schema='public', security_type='SECURITY INVOKER', strictness='CALLED ON NULL INPUT', volatility='VOLATILE'))])
```

which I'm hoping is correct.