### PR TITLE
Support for user defined types

### DIFF
--- a/schemainspect/pg/types.sql
+++ b/schemainspect/pg/types.sql
@@ -1,0 +1,47 @@
+SELECT
+  n.nspname AS schema,
+  pg_catalog.format_type (t.oid, NULL) AS name,
+  t.typname AS internal_name,
+  CASE
+    WHEN t.typrelid != 0
+      THEN CAST ( 'tuple' AS pg_catalog.text )
+    WHEN t.typlen < 0
+      THEN CAST ( 'var' AS pg_catalog.text )
+    ELSE CAST ( t.typlen AS pg_catalog.text )
+  END AS size,
+  pg_catalog.array_to_string (
+    ARRAY(
+      SELECT e.enumlabel
+        FROM pg_catalog.pg_enum e
+        WHERE e.enumtypid = t.oid
+        ORDER BY e.oid ), E'\n'
+    ) AS elements,
+  pg_catalog.obj_description (t.oid, 'pg_type') AS description,
+  (array_to_json(array(
+    select
+      jsonb_build_object('attribute', attname, 'type', a.typname)
+    from pg_class
+    join pg_attribute on (attrelid = pg_class.oid)
+    join pg_type a on (atttypid = a.oid)
+    where (pg_class.reltype = t.oid)
+  )))
+FROM pg_catalog.pg_type t
+LEFT JOIN pg_catalog.pg_namespace n
+  ON n.oid = t.typnamespace
+WHERE ( t.typrelid = 0
+  OR (
+    SELECT c.relkind = 'c'
+      FROM pg_catalog.pg_class c
+      WHERE c.oid = t.typrelid
+  )
+)
+AND NOT EXISTS (
+  SELECT 1
+    FROM pg_catalog.pg_type el
+    WHERE el.oid = t.typelem
+    AND el.typarray = t.oid
+)
+AND n.nspname <> 'pg_catalog'
+AND n.nspname <> 'information_schema'
+AND pg_catalog.pg_type_is_visible ( t.oid )
+ORDER BY 1, 2;


### PR DESCRIPTION
Initial support for user defined types; I say initial because I think there are two things that could be a bit of an issue:

 1. I've not added support for updates. So, types will be dropped and then recreated if needed. It would be nicer to alter them instead.

 2. For some reason `chkpass` is still returned in the list of user defined types. This probably indicates that extensions are being picked up in the set of types returned by `types.sql`.

Any assistance you might be able to render in cleaning up these last two points would be greatly appreciated.