### PR TITLE
fix for Partitioned Tables & Partitioned Indexes

### DIFF
--- a/schemainspect/pg/sql/indexes.sql
+++ b/schemainspect/pg/sql/indexes.sql
@@ -17,7 +17,7 @@ with extension_oids as (
     LEFT JOIN pg_namespace n ON n.oid = c.relnamespace
     left join extension_oids e
       on c.oid = e.objid or i.oid = e.objid
- WHERE c.relkind in ('r', 'm') AND i.relkind in ('i')
+ WHERE c.relkind in ('r', 'm', 'p') AND i.relkind in ('i', 'I')
       -- SKIP_INTERNAL and nspname not in ('pg_catalog', 'information_schema', 'pg_toast')
       -- SKIP_INTERNAL and nspname not like 'pg_temp_%' and nspname not like 'pg_toast_temp_%'
       -- SKIP_INTERNAL and e.objid is null


### PR DESCRIPTION
on postgres 11 (11.2) when table is partitioned with indexes, the indexes are not generated as they have new "relkind"  p = partitioned table, I = partitioned index

example create table:
CREATE TABLE public.test_partitioned_indexes (
	id uuid NOT NULL,
	created_at timestamp not null default current_timestamp,
	is_deleted bool NULL DEFAULT false,
	deleted_at timestamp null,
	CONSTRAINT test_partitioned_indexes_pkey PRIMARY KEY (id,created_at)
)partition by RANGE (created_at);

CREATE INDEX idx_test_partitioned_indexes_created_at ON ONLY public.test_partitioned_indexes USING btree (created_at, is_deleted);


index should be generate....