### PR TITLE
Format key_expressions and partial_predicate as expressions

### DIFF
--- a/schemainspect/pg/sql/indexes.sql
+++ b/schemainspect/pg/sql/indexes.sql
@@ -15,7 +15,8 @@ with extension_oids as (
        indoption key_options, indnatts num_att, indisunique is_unique,
        indisprimary is_pk, indisexclusion is_exclusion, indimmediate is_immediate,
        indisclustered is_clustered, indcollation key_collations,
-       indexprs key_expressions, indpred partial_predicate
+       pg_get_expr(indexprs, indrelid) key_expressions,
+       pg_get_expr(indpred, indrelid) partial_predicate
   FROM pg_index x
     JOIN pg_class c ON c.oid = x.indrelid
     JOIN pg_class i ON i.oid = x.indexrelid

--- a/tests/test_indexes.py
+++ b/tests/test_indexes.py
@@ -1,0 +1,34 @@
+from sqlbag import S
+
+from schemainspect import get_inspector
+
+CREATE = """
+DROP SCHEMA IF EXISTS it CASCADE;
+CREATE SCHEMA it;
+
+CREATE FUNCTION it.key_func(jsonb) RETURNS int AS $$
+SELECT jsonb_array_length($1);
+$$ LANGUAGE SQL IMMUTABLE;
+
+CREATE FUNCTION it.part_func(jsonb) RETURNS boolean AS $$
+SELECT jsonb_typeof($1) = 'array';
+$$ LANGUAGE SQL IMMUTABLE;
+
+CREATE TABLE it.foo(a bigserial, b jsonb);
+
+CREATE UNIQUE INDEX fun_partial_index ON it.foo (it.key_func(b))
+ WHERE it.part_func(b);
+"""
+
+
+def test_indexes(db):
+    with S(db) as s:
+        s.execute(CREATE)
+        i1 = get_inspector(s, schema="it")
+
+        # Recreate schema.
+        # Functions oids will be changed
+        s.execute(CREATE)
+        i2 = get_inspector(s, schema="it")
+
+        assert i1.indexes == i2.indexes


### PR DESCRIPTION
pg_node_tree may contains references to functions

```
({FUNCEXPR :funcid 237969 :funcresulttype 16 :funcretset false ...}).
```

Fix https://github.com/djrobstep/migra/issues/79