### PR TITLE
Add identity support 

### DIFF
--- a/schemainspect/pg/sql/constraints.sql
+++ b/schemainspect/pg/sql/constraints.sql
@@ -15,7 +15,7 @@ with extension_oids as (
     FROM
         pg_indexes
         -- SKIP_INTERNAL where schemaname not in ('pg_catalog', 'information_schema', 'pg_toast')
-				-- SKIP_INTERNAL and schemaname not like 'pg_temp_%' and schemaname not like 'pg_toast_temp_%'
+        -- SKIP_INTERNAL and schemaname not like 'pg_temp_%' and schemaname not like 'pg_toast_temp_%'
     order by
         schemaname, tablename, indexname
 )

--- a/schemainspect/pg/sql/identities.sql
+++ b/schemainspect/pg/sql/identities.sql
@@ -1,0 +1,11 @@
+select
+    table_schema,
+    table_name,
+    column_name,
+    identity_generation,
+from
+    information_schema.columns
+where
+    is_identity = 'YES'
+    -- SKIP_INTERNAL and table_schema not in ('pg_catalog', 'information_schema', 'pg_toast')
+    -- SKIP_INTERNAL and table_schema not like 'pg_temp_%' and schemaname not like 'pg_toast_temp_%'


### PR DESCRIPTION
I'm working on djrobstep/migra#9, and I started by implementing a new Inspected subclass called InspectedIdentity. I also made a SQL file that gets the needed information from information_schema.
`PostgreSQL` (the class) does not use this query yet, as I'm not sure how to fit it in with the rest of the code.

Open questions:
- Should I comment out the entire query with `-- PG_10`?
- Is this even the right way to do it, or should I make these attributes of ColumnInfo?