### PR TITLE
Normalise line-endings in definitions

### DIFF
--- a/schemainspect/pg/obj.py
+++ b/schemainspect/pg/obj.py
@@ -1009,7 +1009,10 @@ class PostgreSQL(DBInspector):
                 identity_arguments=f.identity_arguments,
                 result_string=f.result_string,
                 language=f.language,
-                definition=f.definition,
+                
+                # Proof of concept for line-ending normalisation
+                definition='\n'.join(f.definition.splitlines()),
+                
                 strictness=f.strictness,
                 security_type=f.security_type,
                 volatility=f.volatility,


### PR DESCRIPTION
This change solves a recurring problem we have where a function is defined with crlf (\r\n) in one db, and just LF (\n) in the other. Not intending this change to be merged until it's implemented properly, but I just wanted to ask a couple of questions before going ahead with that

- is this a valid change from your point of view?
- is schemainspect the right place for this change, or should it go in migra?
- should we do the same for views etc?

