### PR TITLE
Allow newlines in function definitions to be ignored

### DIFF
--- a/schemainspect/misc.py
+++ b/schemainspect/misc.py
@@ -30,6 +30,9 @@ class AutoRepr(object):  # pragma: no cover
     def __ne__(self, other):
         return not self == other
 
+    def is_equal(self, other, ignore_newlines=True):
+        return self.__eq__(other)
+
 
 def quoted_identifier(identifier, schema=None, identity_arguments=None):
     s = '"{}"'.format(identifier.replace('"', '""'))

--- a/schemainspect/pg/obj.py
+++ b/schemainspect/pg/obj.py
@@ -39,6 +39,10 @@ COLLATIONS_QUERY_9 = resource_text("sql/collations9.sql")
 RLSPOLICIES_QUERY = resource_text("sql/rlspolicies.sql")
 
 
+def normalize_newlines(text):
+    return '\n'.join(text.splitlines())
+
+
 class InspectedSelectable(BaseInspectedSelectable):
     def has_compatible_columns(self, other):
         def names_and_types(cols):
@@ -246,16 +250,23 @@ class InspectedFunction(InspectedSelectable):
     def drop_statement(self):
         return "drop function if exists {};".format(self.signature)
 
-    def __eq__(self, other):
+    def is_equal(self, other, ignore_newlines=False):
         return (
             self.signature == other.signature
             and self.result_string == other.result_string
-            and self.definition == other.definition
+            and (
+                (normalize_newlines(self.definition.lower()) == normalize_newlines(other.definition.lower()))
+                if ignore_newlines
+                else (self.definition == other.definition)
+            )
             and self.language == other.language
             and self.volatility == other.volatility
             and self.strictness == other.strictness
             and self.security_type == other.security_type
         )
+
+    def __eq__(self, other):
+        return self.is_equal(other, ignore_newlines=False)
 
 
 class InspectedTrigger(Inspected):


### PR DESCRIPTION
This is the companion to https://github.com/djrobstep/migra/pull/105. I'm not sure whether this is the best approach, I confess I'm not a fan of `is_equal` and the awkward it and `__eq__` call each other, but I can't think of a better solution.