### PR TITLE
Fix Issue #4 for Postgres 10 servers

### DIFF
--- a/schemainspect/pg/sql/deps.sql
+++ b/schemainspect/pg/sql/deps.sql
@@ -8,6 +8,7 @@ with things1 as (
     'f' as kind
   from pg_proc
   -- 11_AND_LATER where pg_proc.prokind != 'a'
+  -- 10_AND_EARLIER where pg_proc.proisagg is False
   union
   select
     oid,


### PR DESCRIPTION
Issue #4 was closed but still exists for PG 10 servers. I've added the relevant filter clause to deps.sql for 10_AND_EARLIER servers.