### PR TITLE
Ignore whitespace changes to functions

### DIFF
--- a/schemainspect/pg/obj.py
+++ b/schemainspect/pg/obj.py
@@ -309,7 +309,7 @@ class InspectedFunction(InspectedSelectable):
         return (
             self.signature == other.signature
             and self.result_string == other.result_string
-            and self.definition == other.definition
+            and self.definition.split() == other.definition.split()
             and self.language == other.language
             and self.volatility == other.volatility
             and self.strictness == other.strictness


### PR DESCRIPTION
Hi! Thanks for the great library and the migra tool.

I'm not sure this change is entirely fool proof, but I can't think of a case where whitespace has special meaning, unless the embedded language used is whitespace sensitive (such as Python itself).

At least it has been useful to me when formatting the body of functions for readability, but not making any functional changes beyond whitespace