### PR TITLE
Fix OID confusion when excluding extension indexes

### DIFF
--- a/schemainspect/pg/sql/indexes.sql
+++ b/schemainspect/pg/sql/indexes.sql
@@ -4,7 +4,7 @@ with extension_oids as (
   from
       pg_depend d
   WHERE
-      d.refclassid = 'pg_extension'::regclass
+      d.classid = 'pg_index'::regclass AND d.refclassid = 'pg_extension'::regclass
 ) SELECT n.nspname AS schema,
    c.relname AS table_name,
    i.relname AS name,


### PR DESCRIPTION
When checking for dependencies between an index and an extension we ensure the referenced object is an extension. However, we were missing a check that the dependent object was an index.

When run against a system catalog that has OID collisions between indexes and other database objects this can falsely exclude the index as internal. This crashes later in `load_all_relations` when trying to look up the index referenced by a table:

```
index = self.indexes[index_name]
```

Fix my making sure the dependent database object is an index.
