### PR TITLE
Fix OID confusion when excluding extensions

### DIFF
--- a/schemainspect/pg/sql/constraints.sql
+++ b/schemainspect/pg/sql/constraints.sql
@@ -5,6 +5,7 @@ with extension_oids as (
       pg_depend d
   WHERE
       d.refclassid = 'pg_extension'::regclass
+      and d.classid = 'pg_constraint'::regclass
 ), indexes as (
     select
         schemaname as schema,

--- a/schemainspect/pg/sql/domains.sql
+++ b/schemainspect/pg/sql/domains.sql
@@ -4,7 +4,8 @@ with extension_oids as (
   from
       pg_depend d
   WHERE
-      d.refclassid = 'pg_extension'::regclass
+      d.refclassid = 'pg_extension'::regclass and
+      d.classid = 'pg_type'::regclass 
 )
 SELECT n.nspname as "schema",
        t.typname as "name",

--- a/schemainspect/pg/sql/enums.sql
+++ b/schemainspect/pg/sql/enums.sql
@@ -4,7 +4,8 @@ with extension_oids as (
   from
       pg_depend d
   WHERE
-      d.refclassid = 'pg_extension'::regclass
+      d.refclassid = 'pg_extension'::regclass and
+      d.classid = 'pg_type'::regclass
 )
 SELECT
   n.nspname as "schema",

--- a/schemainspect/pg/sql/indexes.sql
+++ b/schemainspect/pg/sql/indexes.sql
@@ -4,7 +4,8 @@ with extension_oids as (
   from
       pg_depend d
   WHERE
-      d.refclassid = 'pg_extension'::regclass
+      d.refclassid = 'pg_extension'::regclass and
+      d.classid = 'pg_index'::regclass 
 ) SELECT n.nspname AS schema,
    c.relname AS table_name,
    i.relname AS name,

--- a/schemainspect/pg/sql/relations.sql
+++ b/schemainspect/pg/sql/relations.sql
@@ -4,7 +4,8 @@ with extension_oids as (
   from
       pg_depend d
   WHERE
-      d.refclassid = 'pg_extension'::regclass
+      d.refclassid = 'pg_extension'::regclass and
+      d.classid = 'pg_class'::regclass 
 ), enums as (
 
   SELECT

--- a/schemainspect/pg/sql/sequences.sql
+++ b/schemainspect/pg/sql/sequences.sql
@@ -5,7 +5,8 @@ extension_objids as (
     from
         pg_depend d
     WHERE
-        d.refclassid = 'pg_extension'::regclass
+        d.refclassid = 'pg_extension'::regclass and
+        d.classid = 'pg_class'::regclass
 ), pre as (
     select
         n.nspname as schema,

--- a/schemainspect/pg/sql/triggers.sql
+++ b/schemainspect/pg/sql/triggers.sql
@@ -4,7 +4,8 @@ with extension_oids as (
   from
       pg_depend d
   WHERE
-      d.refclassid = 'pg_extension'::regclass
+     d.refclassid = 'pg_extension'::regclass and
+     d.classid = 'pg_trigger'::regclass
 )
 select
     tg.tgname "name",

--- a/schemainspect/pg/sql/types.sql
+++ b/schemainspect/pg/sql/types.sql
@@ -4,7 +4,8 @@ with extension_oids as (
   from
       pg_depend d
   WHERE
-      d.refclassid = 'pg_extension'::regclass
+      d.refclassid = 'pg_extension'::regclass and
+      d.classid = 'pg_type'::regclass
 )
 
 SELECT


### PR DESCRIPTION
When checking for dependencies between an object and an extension we ensure the referenced object is an extension. However, we were missing a check that the dependent object was the correct type. An exception was `functions.sql` which already checked the dependent was a `pg_proc`.

When run against a system catalog that has OID collisions between database objects this can falsely exclude the objects as internal. This usually will crash shortly after due to excluding indexes, relations, etc. that reference each other in the schema.

Fix by replicating the existing `functions.sql` check to the other database object types.
