### PR TITLE
Fix for #55: Skip index on ext table

### DIFF
--- a/schemainspect/pg/sql/schemas.sql
+++ b/schemainspect/pg/sql/schemas.sql
@@ -1,7 +1,18 @@
-select
+with extension_oids as (
+  select
+      objid
+  from
+      pg_depend d
+  WHERE
+      d.refclassid = 'pg_extension'::regclass
+      and d.classid = 'pg_namespace'::regclass
+) select
     nspname as schema
 from
     pg_catalog.pg_namespace
+    left outer join extension_oids e
+    	on e.objid = oid
 -- SKIP_INTERNAL where nspname not in ('pg_internal', 'pg_catalog', 'information_schema', 'pg_toast') 
 -- SKIP_INTERNAL and nspname not like 'pg_temp_%' and nspname not like 'pg_toast_temp_%'
+-- SKIP_INTERNAL and e.objid is null
 order by 1;

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,3 +6,22 @@ from sqlbag import temporary_database
 def db():
     with temporary_database(host="localhost") as dburi:
         yield dburi
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        '--timescale', action='store_true', help='Test with Timescale extension'
+    )
+
+
+def pytest_configure(config):
+    config.addinivalue_line("markers", "timescale: mark timescale specific tests")
+
+
+def pytest_collection_modifyitems(config, items):
+    skip_timescale = pytest.mark.skip(reason="need --timescale option to run")
+    if not config.getoption("--timescale", default=False):
+        # no option given in cli: skip the timescale tests
+        for item in items:
+            if "timescale" in item.keywords:
+                item.add_marker(skip_timescale)


### PR DESCRIPTION
Add tests to SQL in case normal index or constrain refer to extension objects. 
Detect extension schemas.
Add optional testcase for this case.