### PR TITLE
Fix infinite recursion in __repr__

### DIFF
--- a/tests/test_repr.py
+++ b/tests/test_repr.py
@@ -1,0 +1,21 @@
+from sqlbag import S
+
+from schemainspect import get_inspector
+
+
+CREATE = """
+create table t (id integer not null primary key);
+"""
+
+
+def test_repr(db):
+    with S(db) as s:
+        s.execute(CREATE)
+        i = get_inspector(s)
+
+        table = i.tables['"public"."t"']
+        assert repr(table).startswith("InspectedSelectable(")
+
+        c = table.constraints['"public"."t"."t_pkey"']
+        assert repr(c).startswith("InspectedConstraint(")
+        assert "constraint=..." in repr(c)


### PR DESCRIPTION
The auto-generated `__repr__` for inspected objects currently does not work because a lot of objects contain circular references (for example index <-> constraint) which leads to infinite recursion.

This PR adds a fix for this by keeping track of which objects have already been visited during a call to `__repr__` and returning `'...'` for recursive references instead of resolving them. I've shamelessly stolen the technique from the popular "attrs" library: https://github.com/python-attrs/attrs/blob/f680c5b83e65413eeb684c68ece60198015058c3/src/attr/_make.py#L1643
