### PR TITLE
Restore compatibility with Postgres 9.5

### DIFF
--- a/schemainspect/pg/sql/indexes.sql
+++ b/schemainspect/pg/sql/indexes.sql
@@ -67,7 +67,7 @@ WHERE
       -- SKIP_INTERNAL and e.objid is null and er.objid is null
 )
 select * ,
-index_columns[\:key_column_count] as key_columns,
-index_columns[key_column_count+1\:] as included_columns
+index_columns[1\:key_column_count] as key_columns,
+index_columns[key_column_count+1\:array_length(index_columns, 1)] as included_columns
 from pre
 order by 1, 2, 3;


### PR DESCRIPTION
When I run the tests on Postgres 9.5 I get this syntax error:
```
E       sqlalchemy.exc.ProgrammingError: (psycopg2.errors.SyntaxError) syntax error at or near ":"
E       LINE 70: index_columns[:key_column_count] as key_columns,
```

The option to omit lower or upper bound of an array slice seems to have
been introduced between 9.5 and 9.6.

See "Accessing Arrays" in
https://www.postgresql.org/docs/9.5/arrays.html
https://www.postgresql.org/docs/9.6/arrays.html