### PR TITLE
Add support for exclusion constraints

### DIFF
--- a/schemainspect/pg/obj.py
+++ b/schemainspect/pg/obj.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import inspect
+import textwrap
 import sys
 from collections import OrderedDict as od
 from itertools import groupby
@@ -432,7 +433,10 @@ class InspectedIndex(Inspected, TableRelated):
 
     @property
     def create_statement(self):
-        return "{};".format(self.definition)
+        statement = "{};".format(self.definition)
+        if self.constraint and self.constraint.constraint_type == "EXCLUDE":
+            return "select 1; " + textwrap.indent(statement, "-- ")
+        return statement
 
     def __eq__(self, other):
         """
@@ -860,7 +864,7 @@ class InspectedConstraint(Inspected, TableRelated):
 
     @property
     def create_statement(self):
-        if self.index:
+        if self.index and self.constraint_type != "EXCLUDE":
             using_clause = "{} using index {}{}".format(
                 self.constraint_type, self.quoted_name, self.deferrable_subclause
             )

--- a/schemainspect/pg/sql/constraints.sql
+++ b/schemainspect/pg/sql/constraints.sql
@@ -33,10 +33,16 @@ select
     conname as name,
     relname as table_name,
     pg_get_constraintdef(pg_constraint.oid) as definition,
-    tc.constraint_type as constraint_type,
+    case contype
+        when 'c' then 'CHECK'
+        when 'f' then 'FOREIGN KEY'
+        when 'p' then 'PRIMARY KEY'
+        when 'u' then 'UNIQUE'
+        when 'x' then 'EXCLUDE'
+    end as constraint_type,
     i.name as index,
     e.objid as extension_oid,
-    case when tc.constraint_type = 'FOREIGN KEY' then
+    case when contype = 'f' then
         (
             SELECT nspname
             FROM pg_catalog.pg_class AS c
@@ -45,14 +51,14 @@ select
             WHERE c.oid = confrelid::regclass
         )
     end as foreign_table_schema,
-    case when tc.constraint_type = 'FOREIGN KEY' then
+    case when contype = 'f' then
         (
             select relname
             from pg_catalog.pg_class c
             where c.oid = confrelid::regclass
         )
     end as foreign_table_name,
-    case when tc.constraint_type = 'FOREIGN KEY' then
+    case when contype = 'f' then
         (
             select
                 array_agg(ta.attname order by ta.attnum)
@@ -60,7 +66,7 @@ select
             pg_attribute ta where ta.attrelid = conrelid and ta.attnum = any(conkey)
         )
     else null end as fk_columns_local,
-    case when tc.constraint_type = 'FOREIGN KEY' then
+    case when contype = 'f' then
         (
             select
                 array_agg(fa.attname order by fa.attnum)
@@ -68,19 +74,15 @@ select
             pg_attribute fa where fa.attrelid = confrelid and fa.attnum = any(confkey)
         )
     else null end as fk_columns_foreign,
-    tc.constraint_type = 'FOREIGN KEY' as is_fk,
-    tc.is_deferrable = 'YES' as is_deferrable,
-    tc.initially_deferred = 'YES' as initially_deferred
+    contype = 'f' as is_fk,
+    condeferrable as is_deferrable,
+    condeferred as initially_deferred
 from
     pg_constraint
     INNER JOIN pg_class
         ON conrelid=pg_class.oid
     INNER JOIN pg_namespace
         ON pg_namespace.oid=pg_class.relnamespace
-    inner join information_schema.table_constraints tc
-        on nspname = tc.constraint_schema
-        and conname = tc.constraint_name
-        and relname = tc.table_name
     left outer join indexes i
         on nspname = i.schema
         and conname = i.name
@@ -91,7 +93,7 @@ from
       on er.objid = conrelid
     left outer join extension_rels cr
       on cr.objid = confrelid
-    where true
+    where contype in ('c', 'f', 'p', 'u', 'x')
   -- SKIP_INTERNAL and nspname not in ('pg_internal', 'pg_catalog', 'information_schema', 'pg_toast', 'pg_temp_1', 'pg_toast_temp_1')
   -- SKIP_INTERNAL and e.objid is null and er.objid is null and cr.objid is null
 order by 1, 3, 2;

--- a/tests/test_exclusion.py
+++ b/tests/test_exclusion.py
@@ -1,0 +1,49 @@
+from sqlbag import S
+
+from schemainspect import get_inspector
+
+CREATE = """
+create table t (
+    id integer not null primary key,
+    starts_at timestamp not null,
+    ends_at timestamp not null,
+    exclude using gist (tsrange(starts_at, ends_at) with &&) -- disallow overlapping time intervals
+);
+"""
+
+
+def test_exclusion_constraint(db):
+    """
+    Test that Exclusion constraints are parsed, and that SQL for exclusion
+    constraints is generated correctly:
+    - EXCLUDE USING ... is generated
+    - No explicit index creation
+    """
+    with S(db) as s:
+        s.execute(CREATE)
+
+        i = get_inspector(s)
+        constraints_keys = list(i.constraints.keys())
+        assert constraints_keys == [
+            '"public"."t"."t_pkey"',
+            '"public"."t"."t_tsrange_excl"',
+        ]
+        ex_constr = i.constraints['"public"."t"."t_tsrange_excl"']
+        assert ex_constr.constraint_type == "EXCLUDE"
+
+        indexes_keys = list(i.indexes.keys())
+        assert indexes_keys == [
+            '"public"."t_pkey"',
+            '"public"."t_tsrange_excl"',
+        ]
+        ex_index = i.indexes['"public"."t_tsrange_excl"']
+        assert ex_index.constraint == ex_constr
+
+        assert (
+            ex_constr.create_statement
+            == 'alter table "public"."t" add constraint "t_tsrange_excl" EXCLUDE USING gist (tsrange(starts_at, ends_at) WITH &&);'
+        )
+        assert (
+            ex_index.create_statement
+            == "select 1; -- CREATE INDEX t_tsrange_excl ON public.t USING gist (tsrange(starts_at, ends_at));"
+        )


### PR DESCRIPTION
This should fix djrobstep/migra#147

Unfortunately this required some special casing of exclusion constraints in the SQL generation functions.

Exclusion constraints don't show up in `information_schema.table_constraints`,
so remove that table from the constraints query, and use the equivalent fields
from `pg_constraint` directly.

Also, the "USING INDEX" form is not available when creating an exclusion
constraint. The index is always created implicitly. Instead of a "CREATE
INDEX" statement, emit a dummy statement ("select 1;") for indexes that
belong to exclusion constraints.