### PR TITLE
schema/excluded_schema can be a list

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,7 @@ jobs:
       - run:
           name: Wait for db
           command: dockerize -wait tcp://localhost:5432 -timeout 1m
+      - run: sudo apt-get -y update
       - run: sudo apt-get install -y postgresql-client
       - run:
           name: create postgres user
@@ -64,6 +65,7 @@ jobs:
       - run:
           name: Wait for db
           command: dockerize -wait tcp://localhost:5432 -timeout 1m
+      - run: sudo apt-get -y update
       - run: sudo apt-get install -y postgresql-client
       - run:
           name: create postgres user
@@ -112,6 +114,7 @@ jobs:
       - run:
           name: Wait for db
           command: dockerize -wait tcp://localhost:5432 -timeout 1m
+      - run: sudo apt-get -y update
       - run: sudo apt-get install -y postgresql-client
       - run:
           name: create postgres user

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
       - run:
           name: Wait for db
           command: dockerize -wait tcp://localhost:5432 -timeout 1m
-      - run: sudo apt-get -y update
+      - run: sudo apt-get -y update --allow-releaseinfo-change
       - run: sudo apt-get install -y postgresql-client
       - run:
           name: create postgres user
@@ -65,7 +65,7 @@ jobs:
       - run:
           name: Wait for db
           command: dockerize -wait tcp://localhost:5432 -timeout 1m
-      - run: sudo apt-get -y update
+      - run: sudo apt-get -y update --allow-releaseinfo-change
       - run: sudo apt-get install -y postgresql-client
       - run:
           name: create postgres user
@@ -114,7 +114,7 @@ jobs:
       - run:
           name: Wait for db
           command: dockerize -wait tcp://localhost:5432 -timeout 1m
-      - run: sudo apt-get -y update
+      - run: sudo apt-get -y update --allow-releaseinfo-change
       - run: sudo apt-get install -y postgresql-client
       - run:
           name: create postgres user
@@ -163,7 +163,7 @@ jobs:
       - run:
           name: Wait for db
           command: dockerize -wait tcp://localhost:5432 -timeout 1m
-      - run: sudo apt-get -y update
+      - run: sudo apt-get -y update --allow-releaseinfo-change
       - run: sudo apt-get install -y postgresql-client
       - run:
           name: create postgres user

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
       - run:
           name: Install poetry
           command: |
-            sudo pip3 install poetry
+            sudo pip3 install poetry>=1.1.8
             poetry config virtualenvs.create false
       - run:
           command: |
@@ -73,7 +73,7 @@ jobs:
       - run:
           name: Install poetry
           command: |
-            sudo pip3 install poetry
+            sudo pip3 install poetry>=1.1.8
             poetry config virtualenvs.create false
       - run:
           command: |
@@ -122,7 +122,7 @@ jobs:
       - run:
           name: Install poetry
           command: |
-            sudo pip3 install poetry
+            sudo pip3 install poetry>=1.1.8
             poetry config virtualenvs.create false
       - run:
           command: |
@@ -171,7 +171,7 @@ jobs:
       - run:
           name: Install poetry
           command: |
-            sudo pip3 install poetry>=1.0.0
+            sudo pip3 install poetry>=1.1.8
             poetry config virtualenvs.create false
       - run:
           command: |
@@ -207,7 +207,7 @@ jobs:
       - run:
           name: Install poetry, deps
           command: |
-            sudo pip3 install poetry
+            sudo pip3 install poetry>=1.1.8
             poetry config virtualenvs.create false
             python3 -m venv ~/.venv
             . ~/.venv/bin/activate

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,5 @@ pip-wheel-metadata
 
 tests/test_local_*
 scratch
+
+.idea/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,18 +10,18 @@ repository = "https://github.com/djrobstep/schemainspect"
 homepage = "https://github.com/djrobstep/schemainspect"
 
 [tool.poetry.dependencies]
-python = ">=3.6,<4"
+python = ">=3.6 <4"
 six = "*"
 sqlalchemy = "*"
 
 [tool.poetry.dev-dependencies]
 sqlbag = ">=0.1.1616028516"
-pytest = {version="*", python=">=3.5,<4"}
+pytest = {version="*", python=">=3.5 <4"}
 pytest-cov = "*"
-pytest-clarity = {version=">=0.3.0-alpha.0", python=">=3.5,<4"}
+pytest-clarity = {version=">=0.3.0-alpha.0", python=">=3.5 <4"}
 psycopg2-binary = "*"
 flake8 = "*"
-isort = {version=">=5", python=">=3.6,<4"}
+isort = {version=">=5", python=">=3.6 <4"}
 migra = "*"
 black = { version = ">=19.10b0", python=">=3.6" }
 

--- a/schemainspect/get.py
+++ b/schemainspect/get.py
@@ -19,7 +19,13 @@ def get_inspector(x, schema=None, exclude_schema=None):
 
     inspected = ic(c)
     if schema:
-        inspected.one_schema(schema)
+        if isinstance(schema, list):
+            inspected.multiple_schemas(schema)
+        else:
+            inspected.one_schema(schema)
     elif exclude_schema:
-        inspected.exclude_schema(exclude_schema)
+        if isinstance(exclude_schema, list):
+            inspected.exclude_multiple_schemas(exclude_schema)
+        else:
+            inspected.exclude_schema(exclude_schema)
     return inspected

--- a/schemainspect/pg/obj.py
+++ b/schemainspect/pg/obj.py
@@ -1582,20 +1582,20 @@ class PostgreSQL(DBInspector):
         ]  # type: list[InspectedType]
         self.domains = od((t.signature, t) for t in domains)
 
-    def filter_schema(self, schema=None, exclude_schema=None):
-        if schema and exclude_schema:
-            raise ValueError("Can only have schema or exclude schema, not both")
+    def filter_schema(self, schemas=None, exclude_schemas=None):
+        if schemas and exclude_schemas:
+            raise ValueError("Can only have included schema(s) or excluded schema(s), not both")
 
-        def equal_to_schema(x):
-            return x.schema == schema
+        def in_schemas(x):
+            return x.schema in schemas
 
-        def not_equal_to_exclude_schema(x):
-            return x.schema != exclude_schema
+        def not_in_exclude_schemas(x):
+            return x.schema not in exclude_schemas
 
-        if schema:
-            comparator = equal_to_schema
-        elif exclude_schema:
-            comparator = not_equal_to_exclude_schema
+        if schemas:
+            comparator = in_schemas
+        elif exclude_schemas:
+            comparator = not_in_exclude_schemas
         else:
             raise ValueError("schema or exclude_schema must be not be none")
 
@@ -1631,10 +1631,16 @@ class PostgreSQL(DBInspector):
         return d
 
     def one_schema(self, schema):
-        self.filter_schema(schema=schema)
+        self.filter_schema(schemas=[schema])
+
+    def multiple_schemas(self, schema):
+        self.filter_schema(schemas=schema)
 
     def exclude_schema(self, schema):
-        self.filter_schema(exclude_schema=schema)
+        self.filter_schema(exclude_schemas=[schema])
+
+    def exclude_multiple_schemas(self, schema):
+        self.filter_schema(exclude_schemas=schema)
 
     def __eq__(self, other):
         """

--- a/tests/test_excludemultipleschemas.py
+++ b/tests/test_excludemultipleschemas.py
@@ -1,0 +1,34 @@
+from sqlbag import S
+
+from schemainspect import get_inspector
+
+from .test_all import setup_pg_schema
+
+
+def asserts_pg_excludedschemas(i, schema_names, excludedschema_names):
+    schemas = set()
+    for (
+        prop
+    ) in "schemas relations tables views functions selectables sequences enums constraints".split():
+        att = getattr(i, prop)
+        for k, v in att.items():
+            assert v.schema not in excludedschema_names
+            schemas.add(v.schema)
+    assert schemas == set(schema_names)
+
+
+def test_postgres_inspect_excludeschemas(db):
+    with S(db) as s:
+        setup_pg_schema(s)
+        s.execute("create schema thirdschema;")
+        s.execute("create schema forthschema;")
+        s.execute("create schema fifthschema;")
+        # all: public other third forth fifth
+        i = get_inspector(s, exclude_schema=["otherschema", "thirdschema"])
+        asserts_pg_excludedschemas(
+            i, ["public", "forthschema", "fifthschema"], ["otherschema", "thirdschema"]
+        )
+        i = get_inspector(s, exclude_schema=["forthschema", "thirdschema"])
+        asserts_pg_excludedschemas(
+            i, ["public", "otherschema", "fifthschema"], ["forthschema", "thirdschema"]
+        )

--- a/tests/test_multipleschemas.py
+++ b/tests/test_multipleschemas.py
@@ -1,0 +1,23 @@
+from sqlbag import S
+
+from schemainspect import get_inspector
+
+from .test_all import setup_pg_schema
+
+
+def asserts_pg_multipleschemas(i, schema_names):
+    for (
+        prop
+    ) in "schemas relations tables views functions selectables sequences enums constraints".split():
+        att = getattr(i, prop)
+        for k, v in att.items():
+            assert v.schema in schema_names
+
+
+def test_postgres_inspect_multipleschemas(db):
+    with S(db) as s:
+        setup_pg_schema(s)
+        i = get_inspector(s, schema=["schema1", "schema2"])
+        asserts_pg_multipleschemas(i, ["schema1", "schema2"])
+        i = get_inspector(s, schema=["public", "schema"])
+        asserts_pg_multipleschemas(i, "public")


### PR DESCRIPTION
As part of introducing multiple schema inclusion/exclusion in migra, I think this could be an addition:

The get_inspector call can now receive schema/exclude_schema as a list, keeping the backward compatibility with passing simple strings. I added `multiple_schemas` and `exclude_multiple_schemas` methods to `PostgreSQL`, breaking the `filter_schemas` signature compatibility (deep enough in schemainspect that I think breaking it is fine, but that could be adapted). I was tempted to add arguments schemas/exclude_schemas, but didn't in the end.

Added the corresponding unit tests, and AFAIK I'm not breaking the existing tests (tested locally on pg 12)

it fixes #68 by @daa