### PR TITLE
missed the composite types. 

### DIFF
--- a/schemainspect/pg/obj.py
+++ b/schemainspect/pg/obj.py
@@ -1078,6 +1078,7 @@ class PostgreSQL(DBInspector):
         self.load_functions()
         self.selectables = od()
         self.selectables.update(self.relations)
+        self.selectables.update(self.composite_types)
         self.selectables.update(self.functions)
 
         self.load_privileges()


### PR DESCRIPTION
This fixes type diffs not working in migra as well as errors for dependencies on views depending on composite types.
Also, fixes this: https://github.com/djrobstep/migra/issues/171