### PR TITLE
Properly create triggers with status other than the default "origin".

### DIFF
--- a/schemainspect/pg/obj.py
+++ b/schemainspect/pg/obj.py
@@ -365,7 +365,18 @@ class InspectedTrigger(Inspected):
 
     @property
     def create_statement(self):
-        return self.full_definition + ";"
+        status_sql = {
+            'O': 'ENABLE TRIGGER',
+            'D': 'DISABLE TRIGGER',
+            'R': 'ENABLE REPLICA TRIGGER',
+            'A': 'ENABLE ALWAYS TRIGGER'
+        }
+        schema = quoted_identifier(self.schema)
+        table = quoted_identifier(self.table_name)
+        trigger_name = quoted_identifier(self.name)
+        table_alter = f'ALTER TABLE {schema}.{table} {status_sql[self.enabled]} {trigger_name}'
+
+        return self.full_definition + ";\n" + table_alter + ";"
 
     def __eq__(self, other):
         """

--- a/schemainspect/pg/obj.py
+++ b/schemainspect/pg/obj.py
@@ -374,9 +374,11 @@ class InspectedTrigger(Inspected):
         schema = quoted_identifier(self.schema)
         table = quoted_identifier(self.table_name)
         trigger_name = quoted_identifier(self.name)
-        table_alter = f'ALTER TABLE {schema}.{table} {status_sql[self.enabled]} {trigger_name}'
-
-        return self.full_definition + ";\n" + table_alter + ";"
+        if self.enabled in ('D', 'R', 'A'):
+            table_alter = f'ALTER TABLE {schema}.{table} {status_sql[self.enabled]} {trigger_name}'
+            return self.full_definition + ";\n" + table_alter + ";"
+        else:
+            return self.full_definition + ";"
 
     def __eq__(self, other):
         """

--- a/tests/test_triggers.py
+++ b/tests/test_triggers.py
@@ -41,6 +41,7 @@ def test_view_trigger(db):
         # Triggers on views should not include the ALTER TABLE part of the create statement
         assert 'ALTER TABLE' not in trigger.create_statement()
 
+
 def test_replica_trigger(db):
     with S(db) as s:
         s.execute(BASE)
@@ -64,4 +65,4 @@ def test_replica_trigger(db):
         trigger = i.triggers['"public"."my_table"."table_trigger"']
 
         # Replica trigger needs the ALTER TABLE statement as well as the trigger definition
-        assert 'ALTER TABLE' not in trigger.create_statement()
+        assert 'ALTER TABLE' in trigger.create_statement()

--- a/tests/test_triggers.py
+++ b/tests/test_triggers.py
@@ -31,9 +31,37 @@ FOR EACH ROW EXECUTE PROCEDURE my_function();
 """
 
 
-def test_triggers(db):
+def test_view_trigger(db):
     with S(db) as s:
         s.execute(BASE)
         i = get_inspector(s)
 
-        i.triggers['"public"."view_on_table"."trigger_on_view"']
+        trigger = i.triggers['"public"."view_on_table"."trigger_on_view"']
+
+        # Triggers on views should not include the ALTER TABLE part of the create statement
+        assert 'ALTER TABLE' not in trigger.create_statement()
+
+def test_replica_trigger(db):
+    with S(db) as s:
+        s.execute(BASE)
+        function = '''
+        CREATE OR REPLACE FUNCTION table_trigger_function()
+            RETURNS trigger
+            LANGUAGE plpgsql
+        AS $function$
+            BEGIN
+                RETURN NEW;
+            END;
+        $function$
+        ;
+        '''
+        s.execute(function)
+        s.execute('CREATE TRIGGER table_trigger AFTER INSERT ON my_table FOR EACH ROW EXECUTE PROCEDURE table_trigger_function();')
+        s.execute('ALTER TABLLE my_table ENABLE REPLICA TRIGGER table_trigger;')
+
+        i = get_inspector(s)
+
+        trigger = i.triggers['"public"."my_table"."table_trigger"']
+
+        # Replica trigger needs the ALTER TABLE statement as well as the trigger definition
+        assert 'ALTER TABLE' not in trigger.create_statement()


### PR DESCRIPTION
The default status for a trigger is "origin" and the create_statement will create this type of trigger just fine. For the other three types "disabled", "replica", and "always" the create statement needs to be followed by an alter table statement setting the proper trigger type.

Fixes this issue in migra https://github.com/djrobstep/migra/issues/172