### PR TITLE
include defaults in create function signature

### DIFF
--- a/schemainspect/pg/obj.py
+++ b/schemainspect/pg/obj.py
@@ -246,6 +246,7 @@ class InspectedFunction(InspectedSelectable):
         strictness,
         security_type,
         identity_arguments,
+        function_arguments,
         result_string,
         language,
         full_definition,
@@ -254,6 +255,7 @@ class InspectedFunction(InspectedSelectable):
         kind,
     ):
         self.identity_arguments = identity_arguments
+        self.function_arguments = function_arguments
         self.result_string = result_string
         self.language = language
         self.volatility = volatility
@@ -280,6 +282,10 @@ class InspectedFunction(InspectedSelectable):
 
     @property
     def signature(self):
+        return "{}({})".format(self.quoted_full_name, self.function_arguments)
+
+    @property
+    def identity_signature(self):
         return "{}({})".format(self.quoted_full_name, self.identity_arguments)
 
     @property
@@ -304,11 +310,12 @@ class InspectedFunction(InspectedSelectable):
 
     @property
     def drop_statement(self):
-        return "drop {} if exists {};".format(self.thing, self.signature)
+        return "drop {} if exists {};".format(self.thing, self.identity_signature)
 
     def __eq__(self, other):
         return (
-            self.signature == other.signature
+            self.identity_signature == other.identity_signature
+            and self.signature == other.signature
             and self.result_string == other.result_string
             and self.definition == other.definition
             and self.language == other.language
@@ -1561,6 +1568,7 @@ class PostgreSQL(DBInspector):
                 columns=od((c.name, c) for c in columns),
                 inputs=plist,
                 identity_arguments=f.identity_arguments,
+                function_arguments=f.function_arguments,
                 result_string=f.result_string,
                 language=f.language,
                 definition=f.definition,

--- a/schemainspect/pg/sql/functions.sql
+++ b/schemainspect/pg/sql/functions.sql
@@ -207,6 +207,7 @@ unnested as (
             p.extension_oid as extension_oid,
             pg_get_function_result(p.oid) as result_string,
             pg_get_function_identity_arguments(p.oid) as identity_arguments,
+            pg_get_function_arguments(p.oid) as function_arguments,
             pg_catalog.obj_description(p.oid) as comment
         FROM
           unnested p


### PR DESCRIPTION
I noticed when altering the default value of a function parameter that migra didn't pick up that there had been a change.
This was due to only using `pg_get_function_identity_arguments()` for the signature, which does not include defaults.

This change adds an extra column to the `functions.sql` query to get `pg_get_function_arguments(p.oid) as function_arguments` which is then used as the signature for the create function statement. We still use the identity arguments for dropping the function.