### PR TITLE
count for pg15, add support for column options, statistics, and compression

### DIFF
--- a/schemainspect/pg/obj.py
+++ b/schemainspect/pg/obj.py
@@ -1114,10 +1114,14 @@ class PostgreSQL(DBInspector):
 
             if pg_version >= 12:
                 replace = "-- 12_ONLY"
+                if pg_version >= 15:
+                    replace2 = "-- 15_ONLY"
             else:
                 replace = "-- PRE_12"
+                replace2 = "-- PRE_15"
 
-            all_relations_query = all_relations_query.replace(replace, "")
+            all_relations_query = all_relations_query \
+                .replace(replace, "").replace(replace2, "")
             self.ALL_RELATIONS_QUERY = processed(all_relations_query)
             self.COLLATIONS_QUERY = processed(COLLATIONS_QUERY)
             self.RLSPOLICIES_QUERY = processed(RLSPOLICIES_QUERY)
@@ -1422,6 +1426,9 @@ class PostgreSQL(DBInspector):
                     is_identity_always=c.is_identity_always,
                     is_generated=c.is_generated,
                     can_drop_generated=self.pg_version >= 13,
+                    attoptions=c.attoptions,
+                    attstattarget=c.attstattarget,
+                    attcompression=c.attcompression,
                 )
                 for c in clist
                 if c.position_number
@@ -1766,3 +1773,4 @@ class PostgreSQL(DBInspector):
             and self.collations == other.collations
             and self.rlspolicies == other.rlspolicies
         )
+# vim:set ai et ts=4 sts=4 sw=4 cc=80:EOF #

--- a/schemainspect/pg/sql/relations.sql
+++ b/schemainspect/pg/sql/relations.sql
@@ -75,6 +75,10 @@ select
     a.atttypid::regtype AS datatype,
     a.attidentity != '' as is_identity,
     a.attidentity = 'a' as is_identity_always,
+    array_to_string(a.attoptions, ';') as attoptions,
+    a.attstattarget as attstattarget,
+    -- PRE_15 null as attcompression,
+    -- 15_ONLY a.attcompression as attcompression,
     -- PRE_12 false as is_generated,
     -- 12_ONLY a.attgenerated != '' as is_generated,
     (SELECT c.collname FROM pg_catalog.pg_collation c, pg_catalog.pg_type t


### PR DESCRIPTION
We're using migra to distribute DB updates.
Now we went to Pg15.
So, we have to count for new attributes, like `…SET COMPRESSION lz4`.
Plus, we still have to mantain column options (`…SET (opt1=val1,opt2=val2,…)`) and statistics (`…SET STATISTICS 0`).

The patch is to address these issues.