### PR TITLE
fix: Use PEP-517 to specify poetry as build system

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,3 +30,7 @@ schemainspect = 'schemainspect:do_command'
 
 [tool.isort]
 profile = "black"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
The repository uses poetry as build system, which in effect breaks the sdist because poetry, by default, will not include the `.sql` files. Fixing that is done by explicitly specifying that poetry should be used. Poetry will then listen to the specified required files and include the `.sql` files. 